### PR TITLE
Bump golangci-lint to v2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,9 +22,9 @@ jobs:
         with:
           go-version-file: "go.mod"
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
-          version: v1.60.1
+          version: v2.1.1
       - name: go build
         run: go build
   test:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:
-          version: v2.0
+          version: v2.1.1
       - name: go build
         run: go build
   test:


### PR DESCRIPTION
This supersedes https://github.com/skanehira/go-cli-template/pull/70

This bump the GHA to v7 which now requires golangci-lint v2.


> https://github.com/golangci/golangci-lint-action/releases/tag/v7.0.0
> ⚠️ The GitHub Action v7 supports golangci-lint v2 only. ⚠️

