### PR TITLE
Prefer .yaml over .yml

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,4 +1,4 @@
-# This is an example .goreleaser.yml file with some sensible defaults.
+# This is an example .goreleaser.yaml file with some sensible defaults.
 # Make sure to check the documentation at https://goreleaser.com
 
 # The lines below are called `modelines`. See `:help modeline`

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: init
 init:
 ifeq ($(shell uname -s),Darwin)
-	@grep -r -l go-cli-template * .goreleaser.yml | xargs sed -i "" "s/go-cli-template/$$(basename `git rev-parse --show-toplevel`)/"
+	@grep -r -l go-cli-template * .goreleaser.yaml | xargs sed -i "" "s/go-cli-template/$$(basename `git rev-parse --show-toplevel`)/"
 else
-	@grep -r -l go-cli-template * .goreleaser.yml | xargs sed -i "s/go-cli-template/$$(basename `git rev-parse --show-toplevel`)/"
+	@grep -r -l go-cli-template * .goreleaser.yaml | xargs sed -i "s/go-cli-template/$$(basename `git rev-parse --show-toplevel`)/"
 endif


### PR DESCRIPTION
This fixes:
```
❯ make init
grep: .goreleaser.yml: No such file or directory
```