### PR TITLE
Address goreleaser deprecation

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -29,7 +29,7 @@ builds:
       - -X github.com/skanehira/rtty/cmd.Revision={{.ShortCommit}}
 
 archives:
-  - format: tar.gz
+  - formats: tar.gz
     # this name template makes the OS and Arch compatible with the results of `uname`.
     name_template: >-
       {{ .ProjectName }}_
@@ -41,7 +41,7 @@ archives:
     # use zip for windows archives
     format_overrides:
       - goos: windows
-        format: zip
+        formats: zip
 
 changelog:
   sort: asc


### PR DESCRIPTION
> https://goreleaser.com/deprecations/#archivesformat
> Format was renamed to formats, and now accepts a list of formats.
